### PR TITLE
fixed _baseGeometry overwrite in non-animated case

### DIFF
--- a/globe/globe.js
+++ b/globe/globe.js
@@ -166,7 +166,7 @@ DAT.Globe = function(container, opts) {
   }
 
   addData = function(data, opts) {
-    var lat, lng, size, color, i, step, colorFnWrapper;
+    var lat, lng, size, color, i, step, colorFnWrapper, subgeo;
 
     opts.animated = opts.animated || false;
     this.is_animated = opts.animated;
@@ -200,8 +200,14 @@ DAT.Globe = function(container, opts) {
         this._morphTargetId += 1;
       }
       opts.name = opts.name || 'morphTarget'+this._morphTargetId;
+      subgeo = new THREE.Geometry();
+    } else if (this._baseGeometry === undefined) {
+      subgeo = new THREE.Geometry();
+      this._baseGeometry = subgeo;
+    } else {
+      subgeo = this._baseGeometry;
     }
-    var subgeo = new THREE.Geometry();
+
     for (i = 0; i < data.length; i += step) {
       lat = data[i];
       lng = data[i + 1];
@@ -212,8 +218,6 @@ DAT.Globe = function(container, opts) {
     }
     if (opts.animated) {
       this._baseGeometry.morphTargets.push({'name': opts.name, vertices: subgeo.vertices});
-    } else {
-      this._baseGeometry = subgeo;
     }
 
   };


### PR DESCRIPTION
Again, first time user but when running a test similar to the README file it would only display the last series of data added. Looks like when `opts.animated` is `false` the `this._baseGeometry` is overwritten every call to `addData`. This removes all of the previous work done. This patch at least fixes that. Not sure if it's the best way to fix it (never used three.js before).

I should also mention that I get an error (in Firebug) when using the animated globe. It gives a few "padding 0" like console messages then errors out and never sets the size of the points:

```
Error: WebGL: Drawing without vertex attrib 0 array enabled forces the browser to do expensive emulation work when running on desktop OpenGL platforms, for example on Mac. It is preferable to always draw with vertex attrib 0 array enabled, by using bindAttribLocation to bind some always-used attribute to location 0.
```

What browsers and operating systems do the main developers use? Just curious why I might be having more problems than other people. Or is the master branch not necessarily stable?
