### PR TITLE
allow the user to call globe.resize() to resize the global when needed

### DIFF
--- a/globe/globe.js
+++ b/globe/globe.js
@@ -402,6 +402,7 @@ DAT.Globe = function(container, opts) {
   this.createPoints = createPoints;
   this.renderer = renderer;
   this.scene = scene;
+  this.resize = onWindowResize;
 
   return this;
 


### PR DESCRIPTION
Useful when listening to size changes on elements that are not `window`.